### PR TITLE
Bugfix: Recipe styling

### DIFF
--- a/resources/views/recipes/show.blade.php
+++ b/resources/views/recipes/show.blade.php
@@ -103,7 +103,7 @@
             <section class="flex items-center flex-col bg-white rounded my-2 my-2 w-11/12 border-t">
                 <h1 class="text-2xl text-gray-800 mt-4 border-y text-green-600">{{ __('Ingredients') }}</h1>
 
-                <ul class="mt-2 text-gray-600 list-disc">
+                <ul class="mt-2 text-gray-600">
                     @if (count(explode("\r\n", $recipe->ingredients)) > 1)
                         @foreach(explode("\r\n", $recipe->ingredients) as $ingredient)
                             <li>{{ str_replace('\\r\\n', '', $ingredient) }}</li>

--- a/resources/views/recipes/show.blade.php
+++ b/resources/views/recipes/show.blade.php
@@ -117,7 +117,7 @@
             </section>
 
             <!-- Show all steps -->
-            <section class="flex items-center flex-col bg-white rounded mb-8 my-2 w-11/12 border-t">
+            <section class="flex items-center flex-col bg-white rounded mb-8 my-2 w-11/12 border-t w-full">
                 <h1 class="text-2xl text-green-600 mt-4 border-y">{{ __('Steps') }}</h1>
 
                 @forelse ($recipe->steps as $step)


### PR DESCRIPTION
The horizontal position of each instruction to follow in a recipe would vary depending on the screen size. The full width of the parent container is now always taken.

The bullet style from the ingredient list has also been removed.